### PR TITLE
Fixed R 3.6 error

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,2 +1,10 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
+^README\.Rmd$
+^\.travis\.yml$
+^appveyor\.yml$
+^icon\.ai$
+^icon\.png$
+^icon2\.png$
+^sticker\.R$
+^sticker\.png$

--- a/R/get_weights.R
+++ b/R/get_weights.R
@@ -6,9 +6,9 @@
 #' @param sigma standard deviation of Gaussian kernel
 #' @export
 #' @return vector of weights
-#' @examples \dontrun{
-#' 
-#'}
+# @examples \dontrun{
+# 
+#}
 get_weights <- function(offsets, voxelDims, sigma){
     dists = t(apply(offsets, 1, function(x, y) x*y, y=voxelDims))
     sqNorm = apply(dists*dists, 1, function(x) sum(x))

--- a/R/imco_pca.R
+++ b/R/imco_pca.R
@@ -16,9 +16,9 @@
 #' @importFrom rlist list.rbind
 #' @importFrom stats cov.wt
 #' @return Estimated IMCo coupling maps, either written to files and/or returned as nifti objects
-#' @examples \dontrun{
-#' 
-#'}
+# @examples \dontrun{
+# 
+#}
 imco_pca <- function(files, nhoods, nWts, mask_indices, ref=1, verbose=TRUE, retimg=FALSE, outDir=NULL, propMiss=NULL){
     # Restructure to get eigen decomp at each voxel
 	imgVals = lapply(nhoods, function(x) x$values)

--- a/R/imco_reg.R
+++ b/R/imco_reg.R
@@ -17,9 +17,9 @@
 #' @importFrom rlist list.rbind
 #' @importFrom stats coef cov.wt lm.wfit
 #' @return Estimated IMCo coupling maps, either written to files and/or returned as nifti objects
-#' @examples \dontrun{
-#' 
-#'}
+# @examples \dontrun{
+# 
+#}
 imco_reg <- function(files, nhoods, nWts, mask_indices, ref=1, reverse=FALSE, verbose=TRUE, retimg=FALSE, outDir=NULL, propMiss=NULL){
 	if(verbose){
 		cat("# Computing weighted regressions \n")

--- a/R/imco_single.R
+++ b/R/imco_single.R
@@ -11,9 +11,9 @@
 #' @importFrom extrantsr check_ants
 #' @importFrom rlist list.cbind
 #' @return Data frame
-#' @examples \dontrun{
-#' 
-#'}
+# @examples \dontrun{
+# 
+#}
 imco_single <- function(files, vxl, brainMask, subMask=NULL, ref=1, neighborhoodSize=3){
     if(!(as.integer(neighborhoodSize)==neighborhoodSize)){
         stop('neighborhoodSize must be an odd integer')

--- a/R/make_ants_image.R
+++ b/R/make_ants_image.R
@@ -7,9 +7,9 @@
 #' @export
 #' @importFrom ANTsRCore as.antsImage
 #' @return 3D ANTS image of IMCo measurements
-#' @examples \dontrun{
-#' 
-#'}
+# @examples \dontrun{
+# 
+#}
 make_ants_image = function(vec, mask_indices, reference){
 	arr = array(0, dim=dim(reference))
 	arr[mask_indices] = vec

--- a/R/mimosa_data.R
+++ b/R/mimosa_data.R
@@ -23,9 +23,9 @@
 #' @importFrom utils combn
 #' @importFrom WhiteStripe whitestripe whitestripe_norm
 #' @return List of objects
-#' @examples \dontrun{
-#'
-#'}
+# @examples \dontrun{
+#
+#}
 
 mimosa_data <- function (brain_mask, FLAIR, T1, T2 = NULL, PD = NULL, tissue = FALSE,
                          gold_standard = NULL, normalize = 'no', cand_mask = NULL, slices = NULL,

--- a/R/mimosa_fit.R
+++ b/R/mimosa_fit.R
@@ -6,9 +6,9 @@
 #' @export
 #' @importFrom stats glm binomial
 #' @return Returns a glm object containing the trained MIMoSA coefficients.
-#' @examples \dontrun{
-#'
-#'}
+# @examples \dontrun{
+#
+#}
 
 mimosa_fit <- function(training_dataframe, formula) {
 

--- a/R/mimosa_training.R
+++ b/R/mimosa_training.R
@@ -33,9 +33,9 @@
 #' @importFrom utils write.csv
 #' @return GLM objects fit in the MIMoSA procedure and optimal threshold
 #' evaluated for full training set
-#' @examples \dontrun{
-#'
-#'}
+# @examples \dontrun{
+#
+#}
 #### #' @importFrom data.table rbindlist
 
 mimosa_training <- function(brain_mask, FLAIR, T1, T2 = NULL, PD = NULL, tissue = FALSE,

--- a/R/weighted_slr.R
+++ b/R/weighted_slr.R
@@ -8,9 +8,9 @@
 #' @param refImg reference image for header info
 #' @export
 #' @return L list including intercept and slope from both weighted SLRs
-#' @examples \dontrun{
-#' 
-#'}
+# @examples \dontrun{
+# 
+#}
 weighted_slr <- function(x, y, wts, mInds, refImg = NULL) {
   cs = function(x) {
     colSums(x, na.rm = TRUE)

--- a/man/get_weights.Rd
+++ b/man/get_weights.Rd
@@ -19,8 +19,3 @@ vector of weights
 \description{
 Gets weights for IMCo model
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/man/imco_pca.Rd
+++ b/man/imco_pca.Rd
@@ -32,8 +32,3 @@ Estimated IMCo coupling maps, either written to files and/or returned as nifti o
 \description{
 Implements full volumetric IMCo coupling estimation on a single subject using PCA approach
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/man/imco_reg.Rd
+++ b/man/imco_reg.Rd
@@ -34,8 +34,3 @@ Estimated IMCo coupling maps, either written to files and/or returned as nifti o
 \description{
 Implements full volumetric IMCo coupling estimation on a single subject using regression approach
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/man/imco_single.Rd
+++ b/man/imco_single.Rd
@@ -26,8 +26,3 @@ Data frame
 \description{
 Data for coupling estimation on a single subject and single voxel
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/man/make_ants_image.Rd
+++ b/man/make_ants_image.Rd
@@ -19,8 +19,3 @@ make_ants_image(vec, mask_indices, reference)
 \description{
 Convert vector of IMCo into ANTS image
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/man/mimosa_data.Rd
+++ b/man/mimosa_data.Rd
@@ -42,8 +42,3 @@ List of objects
 \description{
 This function creates the training vectors from a single MRI study that has FLAIR, T1, T2, and PD volumes as well as binary masks of lesions. The function can create a tissue mask for the data (or the user can supply a brain mask), the candidate voxels for lesion segmentation, smoothed volumes, and coupling maps. The user may supply already normalized data if they wish to use an alternative normalization method.
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/man/mimosa_fit.Rd
+++ b/man/mimosa_fit.Rd
@@ -17,8 +17,3 @@ Returns a glm object containing the trained MIMoSA coefficients.
 \description{
 This function trains the MIMoSA model from a data.frame produced by an element from the output of the function mimosa_data.
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/man/mimosa_training.Rd
+++ b/man/mimosa_training.Rd
@@ -55,8 +55,3 @@ This function trains the MIMoSA model from the data frames
 produced by mimosa_data on all subjects and determines optimal threshold
 based on training data
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/man/weighted_slr.Rd
+++ b/man/weighted_slr.Rd
@@ -23,8 +23,3 @@ L list including intercept and slope from both weighted SLRs
 \description{
 Returns parameters from weighted regression of y on x (primary) and x on y (secondary, "reverse")
 }
-\examples{
-\dontrun{
-
-}
-}

--- a/vignettes/mimosa_git.Rmd
+++ b/vignettes/mimosa_git.Rmd
@@ -4,7 +4,7 @@ author: "Alessandra Valcarcel"
 date: "`r Sys.Date()`"
 output: rmarkdown::github_document
 vignette: >
-  %\VignetteIndexEntry{mimosa}
+  %\VignetteIndexEntry{mimosa_github}
   %\VignetteEngine{knitr::rmarkdown}
   %\VignetteEncoding{UTF-8}
 ---


### PR DESCRIPTION
Ali, 
- I've fixed the vignette duplicate title error (per release notes, R 3.6 `now checks for duplicated vignette titles (also known as ‘index entries’): they are used as hyperlinks on CRAN package pages and so do need to be unique.`)
- added the top level non-standard files to the .Rbuildignore (this took care of 1 note at compilation)
- commented out empty examples (this took care of the other note at compilation)

Please increase version number and resubmit to neuroc.

