### PR TITLE
wrote dockerfile and wrappers for docker build + run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM pennsive/r-env:base
+
+# install anything not already in pennsive/r-env:base
+RUN r -e "install.packages('rlist')"
+RUN r -e "devtools::install_github('avalcarcel9/mimosa', dependencies = FALSE)"
+
+WORKDIR /src
+COPY . .
+ENTRYPOINT []
+CMD bash

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker build -t pennsive/mimosa:latest .
+

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+docker run -ti --rm pennsive/mimosa:latest
+# run r studio with docker run --rm -d -p 80:8787 -e PASSWORD=123 pennsive/mimosa:latest /init


### PR DESCRIPTION
Build with ./build.sh, run with ./run.sh.

run.sh will drop you in a bash shell so you can easily run Rscript /whatever.R, or, instead do `docker run --rm -d -p 80:8787 -e PASSWORD=123 pennsive/mimosa:latest /init` to launch R studio on http://localhost. The username is rstudio and the password is 123 or whatever you set the PASSWORD env var to.