### PR TITLE
neurodocker approach

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,7 @@
-FROM pennsive/r-env:base
+FROM mimosa_base
 
-# install anything not already in pennsive/r-env:base
-RUN r -e "install.packages('rlist')"
-RUN r -e "devtools::install_github('avalcarcel9/mimosa', dependencies = FALSE)"
+RUN Rscript -e "chooseCRANmirror(graphics=FALSE, ind=56); \
+                install.packages('https://cran.r-project.org/src/contrib/Archive/XML/XML_3.99-0.3.tar.gz', repos=NULL, type='source'); \
+                install.packages('https://cran.r-project.org/src/contrib/Archive/rlist/rlist_0.4.6.tar.gz', repos=NULL, type='source'); \
+                source('https://neuroconductor.org/neurocLite.R'); neuro_install(c('ANTsRCore', 'extrantsr', 'mimosa'))"
 
-WORKDIR /src
-COPY . .
-ENTRYPOINT []
-CMD bash

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,60 @@
 #!/bin/bash
 
-docker build -t pennsive/mimosa:latest .
+set -e
 
+R_VERSION_MAJOR=3
+R_VERSION_MINOR=4
+R_VERSION_PATCH=1
+CONFIGURE_OPTIONS="--with-cairo --with-jpeglib --enable-R-shlib --with-blas --with-lapack"
+
+docker run --rm repronim/neurodocker:0.7.0 generate docker \
+    --pkg-manager apt \
+    --base debian:buster \
+    --fsl version=5.0.8 \
+    --run "apt-get update && apt-get install -y \
+            gfortran \
+            git \
+            g++ \
+            libreadline-dev \
+            libx11-dev \
+            libxt-dev \
+            libpng-dev \
+            libjpeg-dev \
+            libcairo2-dev \   
+            libssl-dev \ 
+            libxml2-dev \
+            libudunits2-dev \
+            libgdal-dev \
+            libbz2-dev \
+            libzstd-dev \
+            liblzma-dev \
+            libpcre2-dev \
+            locales \
+            screen \
+            texinfo \
+            texlive \
+            texlive-fonts-extra \
+            vim \
+            wget \
+            xvfb \
+            tcl8.6-dev \
+            tk8.6-dev \
+            cmake \
+            curl \
+            unzip \
+            libcurl4-gnutls-dev \
+            libgsl-dev \
+            libcgal-dev \
+            libglu1-mesa-dev \
+            libglu1-mesa-dev \
+            libtiff5-dev \
+            && wget https://cran.rstudio.com/src/base/R-${R_VERSION_MAJOR}/R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz \
+            && tar zxvf R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz \
+            && rm R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH}.tar.gz \
+            && cd /R-${R_VERSION_MAJOR}.${R_VERSION_MINOR}.${R_VERSION_PATCH} \
+            && ./configure ${CONFIGURE_OPTIONS} \ 
+            && make \
+            && make install" \
+    | docker build -t mimosa_base -
+
+docker build -t pennsive/mimosa:latest .


### PR DESCRIPTION
Instead of extending the pennsive base images this PR includes all the intermediate containers needed to build the final image, making the installation less opaque and self-contained. R version 3.4.1 is used because the pre-trained mimosa models (in the data directory) were created when the [RData](https://stat.ethz.ch/R-manual/R-devel/library/base/html/save.html) format was on version 2, which R 3.4.1 supports by default (changed in R 3.5)